### PR TITLE
PyCharm into .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ __pycache__
 
 /graveyard-venv
 /gvenv
-/.vscode
 /.directory
 
 /graveyard/settings/local.py
@@ -16,4 +15,9 @@ __pycache__
 
 .DS_store
 
+# Local building tools
 /docker-compose.yml
+
+## Local IDEs dirs
+.idea
+/.vscode


### PR DESCRIPTION
PyCharm creates hidden folder `.idea`, here it is added into `.gitignore` since people can use this IDE.