### PR TITLE
fix: Neohistoric navigation links hidden

### DIFF
--- a/ddcz/templates/base/historic/right_menu.html
+++ b/ddcz/templates/base/historic/right_menu.html
@@ -8,9 +8,15 @@
     <div class="state">online</div>
 
     <ul class="nav_links">
-        <li><a class="text-red" href="">Pošta</a></li>
+
+        <li><a class="text-red" href="{% url 'ddcz:postal-service' %}">Pošta</a></li>
+
         <li><a class="text-red" href="{% url 'ddcz:tavern-list' %}">Putyka</a></li>
+
+        {% comment %}
         <li><a class="text-red" href="">Nastavení</a></li>
+        {% endcomment %}
+
     </ul>
 
     <form method="post" action="{% url 'ddcz:logout-action' %}">

--- a/ddcz/templates/base/historic/top_menu.html
+++ b/ddcz/templates/base/historic/top_menu.html
@@ -4,33 +4,57 @@
         <li><a href="{% url 'ddcz:postal-service' %}">Pošta</a></li>
         <li>&#164;</li>
         {% endif %}
+
         <li><a href="{% url 'ddcz:phorum-list' %}">Fórum</a></li>
         <li>&#164;</li>
+
+        {% comment %}
         <li><a href="">Ankety</a></li>
         <li>&#164;</li>
+
         <li><a href="">Chat</a></li>
         <li>&#164;</li>
+
         <li><a href="">Soutěž O Hlavu Zlatého Draka</a></li>
         <li>&#164;</li>
+        {% endcomment %}
+
         <li><a href="{% url 'ddcz:about-drd' %}">Co je to Dračí Doupě?</a></li>
+
         <li>&#164;</li>
         <li><a href="{% url 'ddcz:web-authors-and-editors' %}">Tvůrci a Redakce</a></li>
+
         <li>&#164;</li>
         <li><a href="{% url 'ddcz:users-list' %}"><b>Uživatelé</b></a></li>
+
+        {% comment %}
         <li>&#164;</li>
         <li><a href="">Dračí líheň</a></li>
+        {% endcomment %}
+
         <li>&#164;</li>
         <li><a href="{% url 'ddcz:newsfeed' %}"><b>Novinky</b></a></li>
+
+        {% comment %}
         <li>&#164;</li>
         <li><a href="">Čekající díla</a></li>
+        {% endcomment %}
+
         <li>&#164;</li>
         <li><a href="{% url 'ddcz:website-manual' %}"><b>Dračí manuál</b></a></li>
+
+        {% comment %}
         <li>&#164;</li>
         <li><a href="{% url 'ddcz:faq' %}"><b>Otázky a Odpovědi</b></a></li>
+        {% endcomment %}
+
         <li>&#164;</li>
         <li><li><a href="https://www.google.com/?q=site:www.dracidoupe.cz">Vyhledávání</a></li></li>
+
+        {% comment %}
         <li>&#164;</li>
         <li><a href=""><b>Rekordy a statistiky</b></a></li>
+        {% endcomment %}
     </ul>
 </nav>
 


### PR DESCRIPTION
Links has not been active, since pages, where links should reffer to, do not exist. They are hidden for now.

Closes #461 