### PR TITLE
Preserve query parameters when changing skin (#252)

### DIFF
--- a/ddcz/templates/base/historic/right_menu.html
+++ b/ddcz/templates/base/historic/right_menu.html
@@ -40,10 +40,10 @@
             <li>
                 <span class="list_heading">Vzhledy</span>
                 <ul>
-                    <li><a href="{% url 'ddcz:change-skin' %}?skin=historic&redirect={{ current_page_url }}">NeoHistoric</a>
+                    <li><a href="{% url 'ddcz:change-skin' %}?skin=historic&redirect={{ current_page_url|urlencode }}">NeoHistoric</a>
                     </li>
-                    <li><a href="{% url 'ddcz:change-skin' %}?skin=light&redirect={{ current_page_url }}">Light</a></li>
-                    <li><a href="{% url 'ddcz:change-skin' %}?skin=dark&redirect={{ current_page_url }}">Dark</a></li>
+                    <li><a href="{% url 'ddcz:change-skin' %}?skin=light&redirect={{ current_page_url|urlencode }}">Light</a></li>
+                    <li><a href="{% url 'ddcz:change-skin' %}?skin=dark&redirect={{ current_page_url|urlencode }}">Dark</a></li>
                 </ul>
             </li>
         </ul>

--- a/ddcz/templates/base/light-dark/right_menu.html
+++ b/ddcz/templates/base/light-dark/right_menu.html
@@ -3,10 +3,10 @@
         <ul class="nav_border">
             <li><span class="list_heading">Vzhled</span>
                 <ul class="list_box">
-                    <li><a href="{% url 'ddcz:change-skin' %}?skin=historic&redirect={{ current_page_url }}">NeoHistoric</a>
+                    <li><a href="{% url 'ddcz:change-skin' %}?skin=historic&redirect={{ current_page_url|urlencode }}">NeoHistoric</a>
                     </li>
-                    <li><a href="{% url 'ddcz:change-skin' %}?skin=light&redirect={{ current_page_url }}">Light</a></li>
-                    <li><a href="{% url 'ddcz:change-skin' %}?skin=dark&redirect={{ current_page_url }}">Dark</a></li>
+                    <li><a href="{% url 'ddcz:change-skin' %}?skin=light&redirect={{ current_page_url|urlencode }}">Light</a></li>
+                    <li><a href="{% url 'ddcz:change-skin' %}?skin=dark&redirect={{ current_page_url|urlencode }}">Dark</a></li>
                 </ul>
             </li>
         </ul>

--- a/ddcz/tests/test_integration/test_skins.py
+++ b/ddcz/tests/test_integration/test_skins.py
@@ -31,6 +31,4 @@ class SkinRedirectTestCase(TestCase):
         self.client.force_login(create_profiled_user("test-user", "password"))
         res = self.client.get(reverse("ddcz:news"), {"z_s": 3, "order": "author"})
 
-        self.assertContains(
-            res, "redirect=/aktuality/%3Fz_s%3D3%26order%3Dauthor"
-        )
+        self.assertContains(res, "redirect=/aktuality/%3Fz_s%3D3%26order%3Dauthor")

--- a/ddcz/tests/test_integration/test_skins.py
+++ b/ddcz/tests/test_integration/test_skins.py
@@ -2,6 +2,8 @@ from django.test import Client, TestCase
 
 from django.urls import reverse
 
+from ..model_generator import create_profiled_user
+
 
 class SkinRedirectTestCase(TestCase):
     fixtures = ["pages"]
@@ -24,3 +26,11 @@ class SkinRedirectTestCase(TestCase):
         )
 
         self.assertEquals("/", res.url)
+
+    def test_skin_links_preserve_current_page_query_parameters(self):
+        self.client.force_login(create_profiled_user("test-user", "password"))
+        res = self.client.get(reverse("ddcz:news"), {"z_s": 3, "order": "author"})
+
+        self.assertContains(
+            res, "redirect=/aktuality/%3Fz_s%3D3%26order%3Dauthor"
+        )


### PR DESCRIPTION
Changing the skin could lose some query parameters from the current page, so you could end up somewhere else than expected. This URL-encodes the redirect value before putting it into the skin links.

I changed both menu variants and added a test with multiple query parameters. Tests, Ruff and the GitHub checks are green.

Fixes #252.