### PR TITLE
Use POST forms for tavern bookmarks (#310)

### DIFF
--- a/ddcz/templates/tavern/table-detail.html
+++ b/ddcz/templates/tavern/table-detail.html
@@ -14,11 +14,14 @@
             <ul>
                 <li><a href="{% url "ddcz:tavern-posts" tavern_table_id=table.id %}">Stůl</a></li>
                 <li>
-                    {% if table.is_bookmarked %}
-                        <a href="{% url "ddcz:tavern-bookmark" tavern_table_id=table.id %}?akce=neoblibit">Zrušit oblíbenost</a>
-                    {% else %}
-                        <a href="{% url "ddcz:tavern-bookmark" tavern_table_id=table.id %}?akce=oblibit">Oblíbit</a>
-                    {% endif %}
+                    <form method="post" action="{% url "ddcz:tavern-bookmark" tavern_table_id=table.id %}">
+                        {% csrf_token %}
+                        {% if table.is_bookmarked %}
+                            <button type="submit" name="action" value="neoblibit">Zrušit oblíbenost</button>
+                        {% else %}
+                            <button type="submit" name="action" value="oblibit">Oblíbit</button>
+                        {% endif %}
+                    </form>
                 </li>
                 {% if table.user_can_admin %}
                     <li><a href="{% url "ddcz:tavern-table-admin" tavern_table_id=table.id %}">Admin</a></li>

--- a/ddcz/tests/test_integration/test_tavern/test_bookmark.py
+++ b/ddcz/tests/test_integration/test_tavern/test_bookmark.py
@@ -1,0 +1,88 @@
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from ddcz.models import TavernBookmark
+from ddcz.tavern import bookmark_table, create_tavern_table
+
+from ...model_generator import get_alphabetic_user_profiles
+
+
+class TestTableBookmark(TestCase):
+    def setUp(self):
+        self.profile = get_alphabetic_user_profiles(
+            number_of_users=1, saved=True, with_corresponding_user=True
+        )[0]
+        self.table = create_tavern_table(
+            owner=self.profile,
+            public=True,
+            name="Public",
+            description="Public Tavern Table",
+        )
+        self.bookmark_url = reverse("ddcz:tavern-bookmark", args=[self.table.pk])
+        self.posts_url = reverse("ddcz:tavern-posts", args=[self.table.pk])
+        self.client = Client()
+        self.client.force_login(self.profile.user)
+
+    def test_get_does_not_change_bookmark_state(self):
+        response = self.client.get(self.bookmark_url, {"action": "oblibit"})
+
+        self.assertEqual(405, response.status_code)
+        self.assertFalse(
+            TavernBookmark.objects.filter(
+                tavern_table=self.table, user_profile=self.profile
+            ).exists()
+        )
+
+    def test_post_books_table(self):
+        response = self.client.post(self.bookmark_url, {"action": "oblibit"})
+
+        self.assertRedirects(response, self.posts_url)
+        self.assertTrue(
+            TavernBookmark.objects.filter(
+                tavern_table=self.table, user_profile=self.profile
+            ).exists()
+        )
+
+    def test_post_unbooks_table(self):
+        bookmark_table(self.profile, self.table)
+
+        response = self.client.post(self.bookmark_url, {"action": "neoblibit"})
+
+        self.assertRedirects(response, self.posts_url)
+        self.assertFalse(
+            TavernBookmark.objects.filter(
+                tavern_table=self.table, user_profile=self.profile
+            ).exists()
+        )
+
+    def test_post_rejects_invalid_action(self):
+        response = self.client.post(self.bookmark_url, {"action": "invalid"})
+
+        self.assertEqual(400, response.status_code)
+
+    def test_post_rejects_missing_action(self):
+        response = self.client.post(self.bookmark_url)
+
+        self.assertEqual(400, response.status_code)
+
+    def test_post_requires_csrf_token(self):
+        csrf_client = Client(enforce_csrf_checks=True)
+        csrf_client.force_login(self.profile.user)
+
+        response = csrf_client.post(self.bookmark_url, {"action": "oblibit"})
+
+        self.assertEqual(403, response.status_code)
+        self.assertFalse(
+            TavernBookmark.objects.filter(
+                tavern_table=self.table, user_profile=self.profile
+            ).exists()
+        )
+
+    def test_table_page_renders_bookmark_form(self):
+        response = self.client.get(self.posts_url)
+
+        self.assertContains(
+            response, f'<form method="post" action="{self.bookmark_url}">'
+        )
+        self.assertContains(response, 'name="csrfmiddlewaretoken"')
+        self.assertContains(response, 'name="action" value="oblibit"')

--- a/ddcz/views/tavern.py
+++ b/ddcz/views/tavern.py
@@ -229,26 +229,19 @@ def notice_board(request, tavern_table_id):
 
 
 @login_required
-@require_http_methods(["HEAD", "GET"])
+@require_http_methods(["POST"])
 @handle_table_visit
 def table_bookmark(request, tavern_table_id):
     table = request.tavern_table
 
-    # TODO: The "Book" button should be a form and it should sent a POST request
-    if "akce" not in request.GET:
-        return HttpResponseBadRequest(
-            "`akce` request parameter is mandatory for this endpoint"
-        )
     try:
-        action = BookmarkActions(request.GET["akce"])
-    except ValueError:
-        return HttpResponseBadRequest(
-            f"Invalid parameter for `akce`: {request.GET['akce']}"
-        )
+        action = BookmarkActions(request.POST.get("action"))
+    except (TypeError, ValueError):
+        return HttpResponseBadRequest("Invalid bookmark action")
 
-    if action == BookmarkActions.BOOK:
+    if action == BookmarkActions.BOOK and not table.is_bookmarked:
         bookmark_table(user_profile=request.ddcz_profile, tavern_table=table)
-    elif action == BookmarkActions.UNBOOK:
+    elif action == BookmarkActions.UNBOOK and table.is_bookmarked:
         unbook_table(user_profile=request.ddcz_profile, tavern_table=table)
 
     return HttpResponseRedirect(

--- a/static/common/css/main.css
+++ b/static/common/css/main.css
@@ -319,11 +319,32 @@ article.link span.actuallink {
     text-transform: uppercase;
 }
 
-#tavern_table_menu li a::before {
+#tavern_table_menu li form {
+    display: inline;
+}
+
+#tavern_table_menu li button {
+    padding: 0;
+    border: 0;
+    background: none;
+    color: var(--link-color);
+    cursor: pointer;
+    font: inherit;
+    text-transform: inherit;
+}
+
+#tavern_table_menu li button:hover,
+#tavern_table_menu li button:focus-visible {
+    color: var(--link-color-hover);
+}
+
+#tavern_table_menu li a::before,
+#tavern_table_menu li button::before {
     content: "[";
 }
 
-#tavern_table_menu li a::after {
+#tavern_table_menu li a::after,
+#tavern_table_menu li button::after {
     content: "]";
 }
 


### PR DESCRIPTION
The bookmark/unbookmark link changes data through GET, which browsers can prefetch. This switches it to a small POST form instead.

I kept the button looking like the old link and added checks for bookmarking, unbookmarking, bad actions, GET requests and CSRF.

Tests and Ruff pass locally, and the GitHub checks are green too.

Fixes #310.