### PR TITLE
Link newsfeed comments to their location

### DIFF
--- a/ddcz/models/used/discussion.py
+++ b/ddcz/models/used/discussion.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.db.models import Q
 from django.urls import reverse
 
 from ..magic import MisencodedCharField, MisencodedTextField
@@ -7,6 +8,7 @@ from .creations import CreativePage
 
 ADD_PHORUM_COMMENT = "a"
 DELETE_PHORUM_COMMENT = "d"
+CREATION_COMMENT_PAGE_SIZE = 10
 
 
 class Phorum(models.Model):
@@ -66,10 +68,12 @@ class CreationComment(models.Model):
     def __str__(self):
         return f"{self.nickname} v {self.foreign_table}"
 
-    def get_absolute_url(self):
+    def get_url_for_page(self, page):
         model = CreativePage.get_model_from_slug(self.foreign_table)
-        creation = model.objects.get(id=self.foreign_id)
-        return reverse(
+        creation = getattr(self, "creation", None) or model.objects.get(
+            id=self.foreign_id
+        )
+        url = reverse(
             "ddcz:creation-detail",
             kwargs={
                 "creative_page_slug": self.foreign_table,
@@ -77,6 +81,17 @@ class CreationComment(models.Model):
                 "creation_slug": creation.get_slug(),
             },
         )
+        page_query = f"?z_s={page}" if page > 1 else ""
+        return f"{url}{page_query}#comment-{self.pk}"
+
+    def get_absolute_url(self):
+        newer_comments = CreationComment.objects.filter(
+            Q(date__gt=self.date) | Q(date=self.date, pk__gt=self.pk),
+            foreign_table=self.foreign_table,
+            foreign_id=self.foreign_id,
+        ).count()
+        page = newer_comments // CREATION_COMMENT_PAGE_SIZE + 1
+        return self.get_url_for_page(page)
 
 
 class Letter(models.Model):

--- a/ddcz/templates/discussions/creation-comments.html
+++ b/ddcz/templates/discussions/creation-comments.html
@@ -24,7 +24,7 @@
     {% pagination comments %}
 
     {% for comment in comments %}
-        <article class="comment">
+        <article class="comment" id="comment-{{ comment.pk }}">
             <picture class="user_icon">
                 {% if comment.by_registered_user %}
                     {% if comment.user.icon_url %}

--- a/ddcz/templates/news/newsfeed.html
+++ b/ddcz/templates/news/newsfeed.html
@@ -18,7 +18,7 @@
     {% for c in comments %}
         <li>
             <article>
-                <h3>{{ c.nickname }}{% if c.creation %} u příspěvku <a href="{{ c.creation.get_canonical_url }}">{{ c.creation.name }}</a>{% endif %}</h3>
+                <h3>{{ c.nickname }}{% if c.creation %} u příspěvku <a href="{{ c.comment_url }}">{{ c.creation.name }}</a>{% endif %}</h3>
 
                 {{ c.text | render_html | safe }}
                 <footer>{{ c.date | commentTime }}</footer>

--- a/ddcz/templatetags/comments.py
+++ b/ddcz/templatetags/comments.py
@@ -2,11 +2,11 @@ from django import template
 from django.core.paginator import Paginator
 from django.utils import timezone
 
-from ddcz.models import CreationComment, TavernPost
+from ddcz.models import CREATION_COMMENT_PAGE_SIZE, CreationComment, TavernPost
 
 register = template.Library()
 
-COMMENT_DEFAULT_LIMIT = 10
+COMMENT_DEFAULT_LIMIT = CREATION_COMMENT_PAGE_SIZE
 
 
 @register.filter
@@ -21,7 +21,7 @@ def commentTime(commentDatetime):
 def creation_comments(context, creative_page_slug, creation_pk):
     comments = CreationComment.objects.filter(
         foreign_table=creative_page_slug, foreign_id=creation_pk
-    ).order_by("-date")
+    ).order_by("-date", "-pk")
 
     paginator = Paginator(comments, COMMENT_DEFAULT_LIMIT)
     comments = paginator.get_page(context["comment_page"])

--- a/ddcz/tests/test_news.py
+++ b/ddcz/tests/test_news.py
@@ -13,7 +13,7 @@ class TestNewsfeed(TestCase):
         self.client = Client()
         cache.clear()
         self.creative_page = CreativePage.objects.create(
-            name="Test Page", slug="testpage", model_class="ddcz.CommonArticle"
+            name="Test Page", slug="testpage", model_class="ddcz.commonarticle"
         )
 
     def test_newsfeed_empty_response(self):

--- a/ddcz/tests/test_news.py
+++ b/ddcz/tests/test_news.py
@@ -13,7 +13,7 @@ class TestNewsfeed(TestCase):
         self.client = Client()
         cache.clear()
         self.creative_page = CreativePage.objects.create(
-            name="Test Page", slug="test-page", model_class="ddcz.CommonArticle"
+            name="Test Page", slug="testpage", model_class="ddcz.CommonArticle"
         )
 
     def test_newsfeed_empty_response(self):
@@ -124,6 +124,75 @@ class TestNewsfeed(TestCase):
         self.assertLessEqual(
             len(response.context["comments"]), settings.NEWSFEED_MAX_COMMENTS
         )
+
+    def test_newsfeed_comment_links_to_the_comment(self):
+        article = CommonArticle.objects.create(
+            name="Test Article",
+            is_published=ApprovalChoices.APPROVED.value,
+            creative_page_slug=self.creative_page.slug,
+            text="Test content",
+        )
+        comment = CreationComment.objects.create(
+            nickname="Tester",
+            email="tester@example.com",
+            text="A useful comment",
+            foreign_table=self.creative_page.slug,
+            foreign_id=article.pk,
+        )
+
+        response = self.client.get("/novinky/")
+
+        self.assertContains(
+            response,
+            f'href="/rubriky/testpage/{article.pk}-test-article/#comment-{comment.pk}"',
+        )
+
+    def test_comment_url_points_to_its_page(self):
+        article = CommonArticle.objects.create(
+            name="Test Article",
+            is_published=ApprovalChoices.APPROVED.value,
+            creative_page_slug=self.creative_page.slug,
+            text="Test content",
+        )
+        older_comment = CreationComment.objects.create(
+            nickname="Tester",
+            email="tester@example.com",
+            text="An older comment",
+            foreign_table=self.creative_page.slug,
+            foreign_id=article.pk,
+        )
+        for index in range(10):
+            CreationComment.objects.create(
+                nickname="Tester",
+                email="tester@example.com",
+                text=f"Newer comment {index}",
+                foreign_table=self.creative_page.slug,
+                foreign_id=article.pk,
+            )
+
+        self.assertEqual(
+            older_comment.get_absolute_url(),
+            f"/rubriky/testpage/{article.pk}-test-article/?z_s=2#comment-{older_comment.pk}",
+        )
+
+    def test_creation_detail_gives_comments_stable_anchors(self):
+        article = CommonArticle.objects.create(
+            name="Test Article",
+            is_published=ApprovalChoices.APPROVED.value,
+            creative_page_slug=self.creative_page.slug,
+            text="Test content",
+        )
+        comment = CreationComment.objects.create(
+            nickname="Tester",
+            email="tester@example.com",
+            text="A useful comment",
+            foreign_table=self.creative_page.slug,
+            foreign_id=article.pk,
+        )
+
+        response = self.client.get(f"/rubriky/testpage/{article.pk}-test-article/")
+
+        self.assertContains(response, f'id="comment-{comment.pk}"')
 
     def test_unpublished_articles_filtered(self):
         """Test that unpublished articles are not shown"""

--- a/ddcz/views/news.py
+++ b/ddcz/views/news.py
@@ -10,7 +10,7 @@ from django.views.decorators.vary import vary_on_cookie
 from django.conf import settings
 
 from ..creations import ApprovalChoices
-from ..models import News, CreativePage, CreationComment
+from ..models import CREATION_COMMENT_PAGE_SIZE, News, CreativePage, CreationComment
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +81,10 @@ def newsfeed(request):
                 comment.creation.creative_page = page_slug_map[comment.foreign_table][
                     "page"
                 ]
+                if settings.NEWSFEED_MAX_COMMENTS <= CREATION_COMMENT_PAGE_SIZE:
+                    comment.comment_url = comment.get_url_for_page(1)
+                else:
+                    comment.comment_url = comment.get_absolute_url()
             except comment_model.DoesNotExist:
                 logger.exception(
                     f"Can't look up creation for comment {comment.pk} for model {comment_model}"


### PR DESCRIPTION
Comments in the newsfeed currently open just the article, so it can take a while to find the actual comment. This adds an anchor to each comment and links to the right comment page, including older comments that ended up on another page.

I added tests for the newsfeed link, the comment anchor, and page 2 links. The full test suite and Ruff pass locally.

Fixes #348