### PR TITLE
Link news authors to their profiles

### DIFF
--- a/ddcz/templates/news/list.html
+++ b/ddcz/templates/news/list.html
@@ -2,6 +2,7 @@
 {% load html %}
 {% load pages %}
 {% load creations %}
+{% load users %}
 
 {% block meta_description %}Domov všech hráčů Dračího Doupěte. Přes dvacet let doplňků, povolání, nestvůr do bestíáře, dobrodružství a debat o nich. Prostor pro seznámení hráčů a hráček a tvorbu družin.{% endblock %}
 
@@ -20,7 +21,13 @@
                 {{ n.text|render_html|safe }}
             </div>
             <footer>
-                <a href="#" class="author" rel="author">{{ n.author }}</a>
+                {% with author_url=n.author|nick_url %}
+                    {% if author_url == "#" %}
+                        <span class="author">{{ n.author }}</span>
+                    {% else %}
+                        <a href="{{ author_url }}" class="author" rel="author">{{ n.author }}</a>
+                    {% endif %}
+                {% endwith %}
             </footer>
         </article>
     {% endfor %}

--- a/ddcz/tests/test_news.py
+++ b/ddcz/tests/test_news.py
@@ -4,8 +4,50 @@ from django.utils import timezone
 from django.core.cache import cache
 from django.conf import settings
 
-from ..models import CreativePage, CreationComment, CommonArticle
+from ..models import CommonArticle, CreationComment, CreativePage, News, UserProfile
 from ..creations import ApprovalChoices
+
+
+class TestNewsList(TestCase):
+    def setUp(self):
+        cache.clear()
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_author_links_to_existing_user_profile(self):
+        author = UserProfile.objects.create(nick="Kronikář")
+        News.objects.create(
+            date=timezone.now(),
+            author=author.nick,
+            author_mail="kronikar@example.com",
+            text="Nová zpráva",
+        )
+
+        response = self.client.get("/aktuality/")
+
+        self.assertContains(
+            response,
+            f'<a href="{author.profile_url}" class="author" rel="author">Kronikář</a>',
+            html=True,
+        )
+
+    def test_unknown_author_is_plain_text_instead_of_void_link(self):
+        News.objects.create(
+            date=timezone.now(),
+            author="Archivář",
+            author_mail="archivar@example.com",
+            text="Stará zpráva",
+        )
+
+        response = self.client.get("/aktuality/")
+
+        self.assertContains(
+            response,
+            '<span class="author">Archivář</span>',
+            html=True,
+        )
+        self.assertNotContains(response, 'href="#"')
 
 
 class TestNewsfeed(TestCase):


### PR DESCRIPTION
News authors currently point to `#`, even when the author has a profile. This links known authors to their profile and leaves old or unmatched names as plain text instead of a broken link.

I added tests for both cases. The full test suite and Ruff pass locally.

Fixes #117